### PR TITLE
Add optional embedded_io compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ description = "A no_std ESC/POS printer driver for embedded systems"
 license = "MIT"
 
 [dependencies]
+embedded-io = { version = "0.6", optional = true }
+
+[features]
+default = []
+embedd_io = ["embedded-io"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,58 @@ pub trait Write {
     fn write(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 }
 
+/// Trait for reading bytes from an underlying transport.
+pub trait Read {
+    /// Error type produced when reading fails.
+    type Error;
+
+    /// Read bytes into the provided buffer, returning the number of bytes read.
+    fn read(&mut self, data: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
 /// A simple ESC/POS printer driver.
 pub struct Printer<T: Write> {
     transport: T,
+}
+
+#[cfg(feature = "embedd_io")]
+mod embedd_io {
+    use super::{Read, Write};
+    use embedded_io::{Read as IoRead, Write as IoWrite};
+
+    /// Wrapper type that provides `embedded_io` compatibility for a transport.
+    pub struct Compat<T>(pub T);
+
+    impl<T> Compat<T> {
+        pub fn new(inner: T) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> T {
+            self.0
+        }
+    }
+
+    impl<T: Read> IoRead for Compat<T> {
+        type Error = T::Error;
+
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            self.0.read(buf)
+        }
+    }
+
+    impl<T: Write> IoWrite for Compat<T> {
+        type Error = T::Error;
+
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            self.0.write(buf)?;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
 }
 
 impl<T: Write> Printer<T> {
@@ -53,6 +102,28 @@ mod tests {
             self.buffer.extend_from_slice(data);
             Ok(())
         }
+    }
+
+    impl Read for MockTransport {
+        type Error = ();
+
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            let len = core::cmp::min(buf.len(), self.buffer.len());
+            buf[..len].copy_from_slice(&self.buffer[..len]);
+            self.buffer.drain(..len);
+            Ok(len)
+        }
+    }
+
+    #[cfg(feature = "embedd_io")]
+    #[test]
+    fn test_embedd_io_compat() {
+        use crate::embedd_io::Compat;
+        let mut transport = Compat::new(MockTransport::new());
+        embedded_io::Write::write_all(&mut transport, b"Hi").unwrap();
+        let mut buf = [0u8; 2];
+        embedded_io::Read::read_exact(&mut transport, &mut buf).unwrap();
+        assert_eq!(&buf, b"Hi");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support `embedd_io` feature gated on the `embedded-io` crate
- implement `Read` trait and wrap transports with `embedd_io::Compat`
- expose `embedded_io::Read` and `embedded_io::Write` implementations
- extend tests to cover the compatibility wrapper

## Testing
- `cargo test` *(fails: failed to download embedded-io crate)*

------
https://chatgpt.com/codex/tasks/task_e_688408485e4483318f5d3f30eb91f49b