### PR TITLE
Add CI to run Rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Cargo check
+        run: cargo check
+      - name: Run tests
+        run: cargo test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `cargo` checks

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6884099cf544833194110d47a6f22415